### PR TITLE
Renamed testrpc to kaya

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# ZilTestRPC
+# Kaya - Zilliqa's RPC client for testing and develoment
 [![Gitter chat](http://img.shields.io/badge/chat-on%20gitter-077a8f.svg)](https://gitter.im/Zilliqa/CommunityDev)
 
-TestRPC is a personal blockchain which makes developing application easier, faster and safer.
-It simulates the Zilliqa's blockchain behavior, and follows the expected server behavior as seen in the [`zilliqa-js`](https://github.com/Zilliqa/Zilliqa-JavaScript-Library).
+Kaya is Zilliqa's RPC server for testing and development. It is personal blockchain which makes developing application easier, faster and safer.
+Kaya simulates the Zilliqa's blockchain behavior, and follows the expected server behavior as seen in the [`zilliqa-js`](https://github.com/Zilliqa/Zilliqa-JavaScript-Library).
 
 The goal of the project is to support all endpoints in Zilliqa Javascript API, making it easy for app developers to build Dapps on our platform. 
 
-Currently, TestRPC supports the following functions:
+Currently, Kaya supports the following functions:
 * `CreateTransaction`
 * `GetTransaction`
 * `GetRecentTransactions`
@@ -27,17 +27,17 @@ In addition, multi-contract calls are not supported yet.
 
 ## Installation
 Run `npm install`, then `node server.js`.
-Debug mode: `DEBUG=testrpc* node server.js`.
+Debug mode: `DEBUG=kaya* node server.js`.
 
 ### Compiling Scilla
 
-You will have to compile the binary yourself to run this testrpc. 
-At the backend, `testrpc` uses the scilla-runner to interpret `.scilla` files
+You will have to compile the binary yourself to run this kaya. 
+At the backend, `Kaya` uses the scilla-runner to interpret `.scilla` files
 
 To compile the binary:
 1. Ensure that you have installed the related dependencies: [INSTALL.md](https://github.com/Zilliqa/scilla/blob/master/INSTALL.md)
 2. Then, run `make clean; make`
-3. Copy the `scilla-runner` from `[SCILLA_DIR]/bin` to `[TESTRPC_DIR]/components/scilla/`
+3. Copy the `scilla-runner` from `[SCILLA_DIR]/bin` to `[Kaya_DIR]/components/scilla/`
 
 ## Server Usage
 
@@ -72,8 +72,8 @@ Sample Test Procedure:
 3. Check where the contract is deployed. It should be on the logs if you have enabled `debug` mode, otherwise you can check it through the `GetSmartContracts` method.
 4. Send a transaction using `node CreateTransaction.js --key [priate_key] --to [Contract_address]`
 
-Mocha tests to be added soon (help appreciated)
+Automated tests to be added soon (help appreciated)
 
 ## License
 
-TestRPC is released under GPLv3. See [license here](https://github.com/Zilliqa/testrpc/blob/master/LICENSE)
+kaya is released under GPLv3. See [license here](https://github.com/Zilliqa/kaya/blob/master/LICENSE)

--- a/components/blockchain.js
+++ b/components/blockchain.js
@@ -1,18 +1,18 @@
 /**
- This file is part of testrpc.
+ This file is part of kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
-  testrpc is free software: you can redistribute it and/or modify it under the
+  kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
  
-  testrpc is distributed in the hope that it will be useful, but WITHOUT ANY
+  kaya is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  
   You should have received a copy of the GNU General Public License along with
-  testrpc.  If not, see <http://www.gnu.org/licenses/>.
+  kaya.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 const config = require('../config');

--- a/components/scilla/scilla.js
+++ b/components/scilla/scilla.js
@@ -1,18 +1,18 @@
 /**
- This file is part of testrpc.
+ This file is part of kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
-  testrpc is free software: you can redistribute it and/or modify it under the
+  kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
  
-  testrpc is distributed in the hope that it will be useful, but WITHOUT ANY
+  kaya is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  
   You should have received a copy of the GNU General Public License along with
-  testrpc.  If not, see <http://www.gnu.org/licenses/>.
+  kaya.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 const fs = require('fs');
@@ -22,7 +22,7 @@ const utilities = require('../../utilities');
 let colors = require('colors');
 
 // debug usage: DEBUG=scilla-txn node server.js
-const debug_txn = require('debug')('testrpc:scilla');
+const debug_txn = require('debug')('kaya:scilla');
 let blockchain_path = 'tmp/blockchain.json'
 
 

--- a/components/wallet/wallet.js
+++ b/components/wallet/wallet.js
@@ -1,18 +1,18 @@
 /**
- This file is part of testrpc.
+ This file is part of kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
-  testrpc is free software: you can redistribute it and/or modify it under the
+  kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
  
-  testrpc is distributed in the hope that it will be useful, but WITHOUT ANY
+  kaya is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  
   You should have received a copy of the GNU General Public License along with
-  testrpc.  If not, see <http://www.gnu.org/licenses/>.
+  kaya.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 
@@ -21,10 +21,10 @@ const crypto = require('crypto');
 const assert = require('assert');
 const zilliqa_util = require('../../lib/util')
 let colors = require('colors');
-var debug_wallet = require('debug')('testrpc:wallet');
+var debug_wallet = require('debug')('kaya:wallet');
 
 
-//@dev: As this is a testrpc, private keys will be stored
+//@dev: As this is a kaya, private keys will be stored
 // note: Real systems do not store private key
 
 // Wallet will store three things - address, private key and balance

--- a/config.js
+++ b/config.js
@@ -1,18 +1,18 @@
 /**
- This file is part of testrpc.
+ This file is part of Kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
-  testrpc is free software: you can redistribute it and/or modify it under the
+  Kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
  
-  testrpc is distributed in the hope that it will be useful, but WITHOUT ANY
+  Kaya is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  
   You should have received a copy of the GNU General Public License along with
-  testrpc.  If not, see <http://www.gnu.org/licenses/>.
+  Kaya.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 /* Configuration file */

--- a/logic.js
+++ b/logic.js
@@ -1,18 +1,18 @@
 /**
- This file is part of testrpc.
+ This file is part of kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
-  testrpc is free software: you can redistribute it and/or modify it under the
+  kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
  
-  testrpc is distributed in the hope that it will be useful, but WITHOUT ANY
+  kaya is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  
   You should have received a copy of the GNU General Public License along with
-  testrpc.  If not, see <http://www.gnu.org/licenses/>.
+  kaya.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 
@@ -27,7 +27,7 @@ const walletCtrl = require("./components/wallet/wallet");
 const blockchain = require('./components/blockchain');
 
 // debug usage: DEBUG=scilla-txn node server.js
-var debug_txn = require("debug")("testrpc:logic");
+var debug_txn = require("debug")("kaya:logic");
 
 // non-persistent states. Initializes whenever server starts
 var repo = {};

--- a/server.js
+++ b/server.js
@@ -1,25 +1,25 @@
 /**
- This file is part of testrpc.
+ This file is part of kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
-  testrpc is free software: you can redistribute it and/or modify it under the
+  kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
  
-  testrpc is distributed in the hope that it will be useful, but WITHOUT ANY
+  kaya is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  
   You should have received a copy of the GNU General Public License along with
-  testrpc.  If not, see <http://www.gnu.org/licenses/>.
+  kaya.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 
 
 const express = require('express');
 const bodyParser = require('body-parser');
-const debug_server = require('debug')('testrpc:server');
+const debug_server = require('debug')('kaya:server');
 const port = 4200;
 const app = express();
 const logic = require('./logic');
@@ -158,7 +158,7 @@ process.on('SIGTERM', shutDown);
 process.on('SIGINT', shutDown);
 
 const server = app.listen(port, (err) => {
-    console.log(`Zilliqa TestRPC Server (ver: 0.0.1)\n`.cyan);
+    console.log(`Zilliqa kaya Server (ver: 0.0.1)\n`.cyan);
 
     if (argv.save) {
         console.log('Save mode enabled');

--- a/test/scripts/CreateTransaction.js
+++ b/test/scripts/CreateTransaction.js
@@ -1,18 +1,18 @@
 /**
- This file is part of testrpc.
+ This file is part of kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
-  testrpc is free software: you can redistribute it and/or modify it under the
+  kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
  
-  testrpc is distributed in the hope that it will be useful, but WITHOUT ANY
+  kaya is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  
   You should have received a copy of the GNU General Public License along with
-  testrpc.  If not, see <http://www.gnu.org/licenses/>.
+  kaya.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 let { Zilliqa } = require('zilliqa-js');

--- a/test/scripts/DeployContract.js
+++ b/test/scripts/DeployContract.js
@@ -1,18 +1,18 @@
 /**
- This file is part of testrpc.
+ This file is part of kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
-  testrpc is free software: you can redistribute it and/or modify it under the
+  kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
  
-  testrpc is distributed in the hope that it will be useful, but WITHOUT ANY
+  kaya is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  
   You should have received a copy of the GNU General Public License along with
-  testrpc.  If not, see <http://www.gnu.org/licenses/>.
+  kaya.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 

--- a/test/scripts/GetState.js
+++ b/test/scripts/GetState.js
@@ -1,18 +1,18 @@
 /**
- This file is part of testrpc.
+ This file is part of kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
-  testrpc is free software: you can redistribute it and/or modify it under the
+  kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
  
-  testrpc is distributed in the hope that it will be useful, but WITHOUT ANY
+  kaya is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  
   You should have received a copy of the GNU General Public License along with
-  testrpc.  If not, see <http://www.gnu.org/licenses/>.
+  kaya.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 

--- a/utilities.js
+++ b/utilities.js
@@ -1,18 +1,18 @@
 /**
- This file is part of testrpc.
+ This file is part of kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
-  testrpc is free software: you can redistribute it and/or modify it under the
+  kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
  
-  testrpc is distributed in the hope that it will be useful, but WITHOUT ANY
+  kaya is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  
   You should have received a copy of the GNU General Public License along with
-  testrpc.  If not, see <http://www.gnu.org/licenses/>.
+  kaya.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 var fs = require('fs');


### PR DESCRIPTION
## Description
Renamed repo to Kaya. 

Zilliqa's Testnet is traditionally named after types of Durian - a type of fruit well-loved in Singapore.
We hope to continue the tradition by naming Zilliqa's tools after well-known food products in Singapore. If anyone were to visit Singapore, be sure to try the Kaya Toast!  

## Review Suggestion
- This PR only contains name changes.

## Status

### Implementation
- [x] **ready for review**